### PR TITLE
Now shutting down pooling threads after emails are sent

### DIFF
--- a/src/main/java/com/manywho/services/email/ApplicationConfiguration.java
+++ b/src/main/java/com/manywho/services/email/ApplicationConfiguration.java
@@ -41,6 +41,10 @@ public class ApplicationConfiguration implements Configuration {
         return host;
     }
 
+    public void setHost(String host) {
+        this.host = host;
+    }
+
     public Integer getPort() {
         return port;
     }
@@ -55,6 +59,10 @@ public class ApplicationConfiguration implements Configuration {
 
     public String getTransport() {
         return transport;
+    }
+
+    public void setTransport(String transport) {
+        this.transport = transport;
     }
 
     public AttachmentSource getAttachmentSource() {
@@ -88,7 +96,6 @@ public class ApplicationConfiguration implements Configuration {
     public void setS3SecretKey(String s3SecretKey) {
         this.s3SecretKey = s3SecretKey;
     }
-
 
     public String getS3Region() {
         return s3Region;

--- a/src/test/java/com/manywho/services/email/test/EmailManagerTest.java
+++ b/src/test/java/com/manywho/services/email/test/EmailManagerTest.java
@@ -1,0 +1,39 @@
+package com.manywho.services.email.test;
+
+import com.manywho.services.email.ApplicationConfiguration;
+import com.manywho.services.email.email.EmailManager;
+import com.manywho.services.email.email.MailerFactory;
+import org.junit.Test;
+import org.simplejavamail.api.email.Email;
+import org.simplejavamail.email.EmailBuilder;
+
+import static org.junit.Assert.assertTrue;
+
+public class EmailManagerTest {
+
+    @Test
+    public void testThatThreadsDoNotStayAroundAfterSendingEmailAsynchronously() throws InterruptedException {
+        ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
+        applicationConfiguration.setHost("example");
+        applicationConfiguration.setTransport("tls");
+
+        Email email = EmailBuilder.startingBlank()
+                .from("Test User", "test@example.com")
+                .to("Test User", "test@example.com")
+                .withPlainText("Some email content")
+                .withSubject("A test email")
+                .buildEmail();
+
+        EmailManager emailManager = new EmailManager(new MailerFactory());
+        for (int i = 0; i < 20; i++) {
+            emailManager
+                    .send(applicationConfiguration, email, false);
+        }
+
+        // Wait for the email sending threads to (probably) complete
+        Thread.sleep(1000);
+
+        // Ensure all the threads actually shut down
+        assertTrue("There are still threads running when there shouldn't be", Thread.activeCount() < 5);
+    }
+}


### PR DESCRIPTION
When sending emails asynchronously, the email library being used creates extra threads per-`Mailer` for pooling. It doesn't seem possible to disable this pooling capability (it's not useful in this service as each email will use different credentials, so we can't keep `Mailer` instances around), so the service should be shutting down the pooling threads after the email is sent (or fails).

Keeping these unused threads around eventually causes either thread starvation or greatly increased CPU usage, potentially bringing a host down.